### PR TITLE
Support for multiple GCC versions

### DIFF
--- a/lib/Linux/buildlib.sh
+++ b/lib/Linux/buildlib.sh
@@ -2,9 +2,29 @@
 cp ./../../src/*.* ./
 cp ./../../include/*.* ./
 
-g++ -std=c++0x -w -c *.cpp
+# Query for the version of GCC that is being used
+VERSION=$(gcc -dumpversion)
+
+# Split the version string using the periods and create an array in order to
+# extract the major and minor version numbers
+VERSION=(${VERSION//./ })
+MAJOR=${VERSION[0]}
+MINOR=${VERSION[1]}
+
+# Set the C++ standard based upon the version of GCC available
+if [ ${MAJOR} -eq 4 ] && [ ${MINOR} -gt 6 ]
+then
+  echo ${MAJOR} ${MINOR}
+  CXXSTD="c++11"
+else
+  CXXSTD="c++0x"
+fi
+
+# Compile and link
+g++ -std=${CXXSTD} -w -c *.cpp
 ar rvs modus.a *.o
 
+# Clean up
 rm -f *.o
 rm -f *.cpp
 rm -f *.h


### PR DESCRIPTION
The flag value used to specify the use of the 2011 standard for C++ changed from version 4.6 to 4.7. These changes query gcc to determine which version it is, and sets the -std flag accordingly.
