### PR TITLE
Added const to eliminate warning

### DIFF
--- a/include/mlist.h
+++ b/include/mlist.h
@@ -49,7 +49,7 @@ class MCList
 protected:
     std::vector<EntryType> sEntry;
 
-    int readScriptValue(char* sLine, char* sField)
+    int readScriptValue(char* sLine, const char* sField)
     {
         char* sSegment = strstr(sLine, sField);
 


### PR DESCRIPTION
When building with gcc I get the following warning in several places,

warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]

This happens because there are string literals being passed to readScriptValue
as char_. The fix for this is to change the signature of readScriptValue to take
const char_, which is consistent with strstr() where the variable is used, and
eliminates the compiler warning.
